### PR TITLE
Fix random board generation.

### DIFF
--- a/src/util/board_gen.rs
+++ b/src/util/board_gen.rs
@@ -8,10 +8,10 @@ pub fn random_board_with_moves<B: Board>(start: &B, n: u32, rng: &mut impl Rng) 
     //this implementation could be made faster with backtracking instead of starting from scratch,
     // but this only starts to matter for very high n and that's not really the main use case
 
-    loop {
+    'newtry: loop {
         let mut board = start.clone();
         for _ in 0..n {
-            if board.is_done() { break; }
+            if board.is_done() { continue 'newtry; }
             board.play(board.random_available_move(rng))
         }
         return board;


### PR DESCRIPTION
Hello,
I believe that the function `random_board_with_moves` was incorrectly implemented.
Indeed, if the board was done before `n` moves, the inner `for` loop would break and the function would return the done board with less than `n` moves.
I think this PR fixes this behaviour.