### PR TITLE
Implementation of monster-chess

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {}
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rayon = "1.5.2"
 chess = "3.2.0"
 arimaa_engine_step = { version = "1.0.1" } # , path = "../arimaa-engine-step"
 once_cell = "1.12.0"
+monster_chess = "0.0.1"
 
 # temporary fix until https://github.com/jordanbray/chess/pull/67 is merged
 [profile.dev.build-override]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rayon = "1.5.2"
 chess = "3.2.0"
 arimaa_engine_step = { version = "1.0.1" } # , path = "../arimaa-engine-step"
 once_cell = "1.12.0"
-monster_chess = "0.0.1"
+monster_chess = "0.0.3"
 
 # temporary fix until https://github.com/jordanbray/chess/pull/67 is merged
 [profile.dev.build-override]

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -5,6 +5,7 @@ pub mod connect4;
 pub mod oware;
 pub mod sttt;
 pub mod ttt;
+pub mod monster_chess;
 
 pub mod dummy;
 pub mod max_length;

--- a/src/games/monster_chess.rs
+++ b/src/games/monster_chess.rs
@@ -1,0 +1,38 @@
+use monster_chess::board::Board as NativeBoard;
+
+use crate::{board::{Board, Player, BoardMoves, BoardSymmetry}, impl_unit_symmetry_board, symmetry::UnitSymmetry};
+
+pub struct MonsterBoard<'a, const T: usize>(pub NativeBoard<'a, T>);
+
+// Couldn't use the `impl_unit_symmetry_board` because of MonsterBoard's generics.
+impl<'a, const T: usize> BoardSymmetry<MonsterBoard<'a, T>> for MonsterBoard<'a, T> {
+    type Symmetry = UnitSymmetry;
+    type CanonicalKey = ();
+
+    fn map(&self, _: Self::Symmetry) -> Self {
+        self.clone()
+    }
+
+    fn map_move(
+        &self,
+        _: Self::Symmetry,
+        mv: <MonsterBoard<'a, T> as Board>::Move,
+    ) -> <MonsterBoard<'a, T> as Board>::Move {
+        mv
+    }
+
+    fn canonical_key(&self) -> Self::CanonicalKey {}
+}
+
+impl<'a, const T: usize> BoardMoves<'a, MonsterBoard<'a, T>> for MonsterBoard<'a, T> {
+     
+}
+
+impl<'a, const T: usize> Board for MonsterBoard<'a, T> {
+    fn next_player(&self) -> Player {
+        match self.0.state.moving_team {
+            0 => Player::A,
+            1 => Player::B
+        }
+    }
+}

--- a/src/games/monster_chess.rs
+++ b/src/games/monster_chess.rs
@@ -1,11 +1,23 @@
-use monster_chess::board::Board as NativeBoard;
+use internal_iterator::InternalIterator;
+use monster_chess::board::{Board as NativeBoard, actions::Action};
+use std::fmt;
+use std::fmt::Display;
+use std::slice::Iter;
 
 use crate::{board::{Board, Player, BoardMoves, BoardSymmetry}, impl_unit_symmetry_board, symmetry::UnitSymmetry};
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct MonsterBoard<'a, const T: usize>(pub NativeBoard<'a, T>);
 
+impl<'a, const T: usize> Display for MonsterBoard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Use `self.number` to refer to each positional data point.
+        write!(f, "{}", self.0);
+    }
+}
+
 // Couldn't use the `impl_unit_symmetry_board` because of MonsterBoard's generics.
-impl<'a, const T: usize> BoardSymmetry<MonsterBoard<'a, T>> for MonsterBoard<'a, T> {
+impl<const T: usize> BoardSymmetry<MonsterBoard<'static, T>> for MonsterBoard<'static, T> {
     type Symmetry = UnitSymmetry;
     type CanonicalKey = ();
 
@@ -16,23 +28,27 @@ impl<'a, const T: usize> BoardSymmetry<MonsterBoard<'a, T>> for MonsterBoard<'a,
     fn map_move(
         &self,
         _: Self::Symmetry,
-        mv: <MonsterBoard<'a, T> as Board>::Move,
-    ) -> <MonsterBoard<'a, T> as Board>::Move {
+        mv: <MonsterBoard<'static, T> as Board>::Move,
+    ) -> <MonsterBoard<'static, T> as Board>::Move {
         mv
     }
 
     fn canonical_key(&self) -> Self::CanonicalKey {}
 }
 
-impl<'a, const T: usize> BoardMoves<'a, MonsterBoard<'a, T>> for MonsterBoard<'a, T> {
-     
+impl<'a, const T: usize> BoardMoves<'a, MonsterBoard<'static, T>> for MonsterBoard<'static, T> {
+    type AllMovesIterator = dyn Iterator<Item = Action>;
+    type AvailableMovesIterator = dyn Iterator<Item = Action>;
+
+    fn all_possible_moves() {
+        
+    }
+
+    fn available_moves(&self) -> Result<Self::AvailableMovesIterator, crate::board::BoardDone> {
+        self.0.generate_legal_moves(0)
+    }
 }
 
-impl<'a, const T: usize> Board for MonsterBoard<'a, T> {
-    fn next_player(&self) -> Player {
-        match self.0.state.moving_team {
-            0 => Player::A,
-            1 => Player::B
-        }
-    }
+impl<'a, const T: usize> Board for MonsterBoard<'static, T> {
+    
 }


### PR DESCRIPTION
This is the initial commit of implementing `monster-chess` into board-game-rs. All this initial commit does is support Rust in Github codespaces so that I can more easily develop this. There's no progress yet, but I'll be implementing this on the fork and will comment once this is ready for review.